### PR TITLE
Update output format

### DIFF
--- a/netanalysis/blocktest/measure.sh
+++ b/netanalysis/blocktest/measure.sh
@@ -111,6 +111,7 @@ function test_sni_blocking() {
 # it can provide positive confirmation that the query was not discarded.
 # It relies on the high capacity and availability of the root nameservers
 # and the fact that they are not blockable due to substantial collateral damage.
+# TODO: Test TCP and upper case.
 function test_dns_injection() {
   echo "DNS_INJECTION"
   declare -r domain=$1

--- a/netanalysis/blocktest/measure.sh
+++ b/netanalysis/blocktest/measure.sh
@@ -50,6 +50,7 @@ function test_http_blocking() {
   local domain=$1
   # TODO: use a domain we control instead of example.com, which may change without notice.
   # TODO: This breaks if the test domain is hosted in the target host.
+  # TODO: This may capture censorship happening in the test server network.
   local http_response
   http_response=$(curl --silent --show-error --max-time 5 --connect-to ::example.com: http://$domain/ 2>&1)
   local http_result=$?

--- a/netanalysis/blocktest/measure.sh
+++ b/netanalysis/blocktest/measure.sh
@@ -36,10 +36,17 @@ function is_online() {
   ((status == "204"))
 }
 
+function print_client_info() {
+  declare -r client_info="$(curl --silent https://ipinfo.io |  sed 's/ *"\(.*\)": "\(.*\)",$/\1: \2/')"
+  echo client_country: $(echo "$client_info" | grep '^country:' | cut -d' ' -f 2-)
+  echo client_as: $(echo "$client_info" | grep '^org:' | cut -d' ' -f 2-)
+}
+
 # The HTTP test works by connecting to a well-behaved baseline that always returns the same output
 # on invalid hostname. We then compare the output for our test domain and a domain we know
 # is invalid. If the result changes, then we know there was injection.
 function test_http_blocking() {
+  echo "HTTP"
   local domain=$1
   # TODO: use a domain we control instead of example.com, which may change without notice.
   local http_response
@@ -48,22 +55,22 @@ function test_http_blocking() {
   if ((http_result == CURLE_OK)); then 
     local expected_reponse=$(curl --silent --show-error --max-time 5 --connect-to ::example.com: http://inexistent.example.com/ 2>&1)
     if diff <(echo "$http_response") <(echo "$expected_reponse") > /dev/null; then
-      echo HTTP:OK Got expected response
+      echo "  analysis: OK - Got expected response"
     else
-      echo HTTP:INTERFERENCE Got injected response
+      echo "  analysis: INTERFERENCE - Got injected response"
       diff <(echo "$http_response") <(echo "$expected_reponse")
     fi
   elif ((http_result == CURLE_GOT_NOTHING)); then
-    echo "HTTP:INTERFERENCE Unexpected empty response when Host is $domain($http_response)"
+    echo "  analysis: INTERFERENCE - Unexpected empty response when Host is $domain($http_response)"
   elif ((http_result == CURLE_RECV_ERROR)); then
-    echo "HTTP:INTERFERENCE Cannot from established connection when Host is $domain($http_response)"
+    echo "  analysis: INTERFERENCE - Cannot from established connection when Host is $domain($http_response)"
   elif ((http_result == CURLE_OPERATION_TIMEDOUT)); then
-    echo "HTTP:LIKELY_INTERFERENCE Unexpected time out when Host is $domain ($http_response)"
+    echo "  analysis: LIKELY_INTERFERENCE - Unexpected time out when Host is $domain ($http_response)"
   elif ((http_result == CURLE_COULDNT_CONNECT)); then
-    echo "HTTP:INCONCLUSIVE Failed to connect to innocuous domain ($http_response)"
+    echo "  analysis: INCONCLUSIVE - Failed to connect to innocuous domain ($http_response)"
   else
     # TODO: Find out what errors are guaranteed blocking.
-    echo "HTTP:INCONCLUSIVE Failed to fetch test domain from innocuous domain ($http_response)"
+    echo "  analysis: INCONCLUSIVE - Failed to fetch test domain from innocuous domain ($http_response)"
   fi
 }
 
@@ -73,26 +80,27 @@ function test_http_blocking() {
 # If we get a ServerHello and the CA chain is valid, then we know there was no injection and
 # can conclude there's no blocking.
 function test_sni_blocking() {
+  echo "SNI"
   local domain=$1
   # The `local` call will override `#?`, so we don't assign on the declaration.
   local curl_error
   curl_error=$(curl --silent --show-error --max-time 5 --connect-to ::example.com: "https://$domain/" 2>&1 >/dev/null)
   curl_result=$?
   if ((curl_result == CURLE_PEER_FAILED_VERIFICATION || curl_result == CURLE_OK)); then 
-    echo "SNI:OK Got TLS ServerHello"
+    echo "  analysis: OK - Got TLS ServerHello"
   elif ((curl_result == CURLE_SSL_CACERT)) && \
        [[ "$curl_error" =~ "no alternative certificate subject name matches target host name" ]]; then
     # On Linux curl outputs CURLE_SSL_CACERT for invalid subject name 🤷.
-    echo "SNI:OK Got TLS ServerHello"
+    echo "  analysis: OK - Got TLS ServerHello"
   elif ((curl_result == CURLE_GOT_NOTHING)); then
-    echo "SNI:INTERFERENCE Unexpected empty response when SNI is $domain ($curl_error)"
+    echo "  analysis: INTERFERENCE - Unexpected empty response when SNI is $domain ($curl_error)"
   elif ((curl_result == CURLE_SSL_CONNECT_ERROR)); then
-    echo "SNI:LIKELY_INTERFERENCE Unexpected TLS error when SNI is $domain ($curl_error)"
+    echo "  analysis: LIKELY_INTERFERENCE - Unexpected TLS error when SNI is $domain ($curl_error)"
   else
     # TODO: Check for invalid CA chain: that indicates the server is misconfigured or
     # there's MITM going on.
     # TODO: Figure out what errors are guaranteed blocking.
-    echo "SNI:INCONCLUSIVE Failed to get TLS ServerHello ($curl_error)"
+    echo "  analysis: INCONCLUSIVE - Failed to get TLS ServerHello ($curl_error)"
   fi
 }
 
@@ -104,25 +112,30 @@ function test_sni_blocking() {
 # It relies on the high capacity and availability of the root nameservers
 # and the fact that they are not blockable due to substantial collateral damage.
 function test_dns_injection() {
+  echo "DNS_INJECTION"
   declare -r domain=$1
   declare -r root_nameserver=$(dig +short . ns | head -1)
   if [[ -z "$root_nameserver" ]]; then
-    echo DNS_INJECTION:INCONCLUSIVE "Could not get root nameserver"
+    echo "  root_nameserver_error: Could not get root nameserver"
+    echo "  analysis: INCONCLUSIVE - Could not run test"
     return 2
   fi
+  echo "  root_nameserver: $root_nameserver"
   declare response
   if ! response=$(dig +time=2 @$root_nameserver $domain); then
-    echo DNS_INJECTION:INTERFERENCE "Could not get response"
+    echo "  query_error: Could not get response"
+    echo "  analysis: INTERFERENCE - Could not get response"
     return 1
   fi
   declare -r status=$(echo $response | grep -oE 'status: \w+' | cut -d ' ' -f 2)
   declare -ri num_answers=$(echo $response | grep -oE 'ANSWER: \w+' | cut -d ' ' -f 2)
-  declare -ri num_auth=$(echo $response | grep -oE 'AUTHORITY: \w+' | cut -d ' ' -f 2)
-  if [[ $status == 'NOERROR' && $num_answers == 0 && $num_auth -ge 1 ]]; then
-    echo DNS_INJECTION:OK "Received expected response"
+  declare -ri num_authorities=$(echo $response | grep -oE 'AUTHORITY: \w+' | cut -d ' ' -f 2)
+  echo "  query_response: status=$status, num_answers=$num_answers, num_authorities=$num_authorities"
+  if [[ $status == 'NOERROR' && $num_answers == 0 && $num_authorities -ge 1 ]]; then
+    echo "  analysis: OK - Received expected response"
     return 0
   fi
-  echo DNS_INJECTION:INTERFERENCE "Received unexpected response: $response"
+  echo "  analysis: INTERFERENCE - Received unexpected response: $response"
   return 1
 }
 
@@ -136,18 +149,26 @@ function test_dns_blocking() {
     # There's no point in testing the system resolver if we know reponses are injected.
     return
   fi
+  
+  echo "SYSTEM_RESOLVER"
+  declare -r resolver_ip="$(dig +short TXT whoami.ds.akahelp.net | grep ns | cut -d\" -f 4)"
+  declare -r resolver_info="$(curl --silent https://ipinfo.io/${resolver_ip} |  sed 's/ *"\(.*\)": "\(.*\)",$/\1: \2/')"
+  echo "  resolver_country: $(echo "$resolver_info" | grep '^country:' | cut -d' ' -f 2-)"
+  echo "  resolver_ip: $(echo "$resolver_info" | grep '^ip:' | cut -d' ' -f 2-)"
+  echo "  resolver_as: $(echo "$resolver_info" | grep '^org:' | cut -d' ' -f 2-)"
 
   declare -r ips=$(dig +dnssec +short $domain |  grep -o -E '([0-9]+\.){3}[0-9]+' | sort)
+  echo "  response_ips: $ips"
   declare -r ip_result=$(test_ips "$ips" "$domain")
   case $(echo $ip_result | cut -d\  -f 1) in
     IP_INVALID)
-      echo SYSTEM_RESOLVER:INTERFERENCE $ip_result
+      echo "  analysis: INTERFERENCE - $ip_result"
       ;;
     IP_VALID)
-      echo SYSTEM_RESOLVER:OK $ip_result
+      echo "  analysis: OK - $ip_result"
       ;;
     *)
-      echo SYSTEM_RESOLVER:INCONCLUSIVE $ip_result
+      echo "  anslysis: INCONCLUSIVE - $ip_result"
   esac
 }
 
@@ -164,14 +185,14 @@ function test_ips() {
   local ips=$1
   local domain=$2
   if [[ $ips == "" ]]; then
-    echo IP_INVALID Did not get any IPs from DNS resolver
-    return
+    echo "IP_INVALID Did not get any IPs from DNS resolver"
+    return 1
   fi
   local ip=$(echo "$ips" | head -1)
   local ip_info=$(curl --silent "https://ipinfo.io/$ip")
   if echo "$ip_info" | grep "bogon" > /dev/null; then
-    echo IP_INVALID IP $ip is bogus
-    return
+    echo "IP_INVALID IP $ip is bogus"
+    return 1
   fi
 
   # Validate IPs by comparing to a trusted resolution.
@@ -185,7 +206,7 @@ function test_ips() {
   local common_ips=$(comm -12 <(echo "$ips") <(echo "$ips_from_doh"))
   if (( $(echo "$common_ips" | wc -w) > 0)); then
     echo IP_VALID Resolved IPs [$common_ips] were found on dns.google.com using DNS-over-HTTPS
-    return
+    return 0
   fi
 
   # Validate IPs by establishing a TLS connection.
@@ -196,34 +217,30 @@ function test_ips() {
   local result=$?
   if ((result == CURLE_OK)) ; then
     echo "IP_VALID Resolved IP $ip can produce certificate for domain $domain"
-    return
+    return 0
   elif ((result == CURLE_PEER_FAILED_VERIFICATION)); then
     echo "IP_INVALID IP $ip cannot produce domain certificate"
-    return
+    return 1
   else
     echo "IP_INCONCLUSIVE Could not validate ips [$ips]. TLS test failed ($curl_error)"
-    return
+    return 2
   fi
   # Other tests to try:
   # - Recurse with dnssec and qname minimization
 }
 
 function main() {
-  date -u
+  echo time: "$(date -u)"
   if ! is_online; then
     echo "You are offline"
     return 1
   fi
+
   local domain=$1
-  echo YOUR NETWORK
-  curl https://ipinfo.io
+  echo domain: $domain
+  print_client_info
   echo
 
-  printf "\nYOUR DNS RESOLVER\n"
-  curl https://ipinfo.io/$(dig +short TXT whoami.ds.akahelp.net | grep ns | cut -d\" -f 4)
-  echo
-
-  printf "\nTESTS\n"
   test_http_blocking $domain
   test_sni_blocking $domain
   test_dns_blocking $domain

--- a/netanalysis/blocktest/measure.sh
+++ b/netanalysis/blocktest/measure.sh
@@ -214,17 +214,6 @@ function test_dns_blocking() {
   fi
   # Other tests to try:
   # - Recurse with dnssec and qname minimization
-
-  case $(echo $ip_result | cut -d\  -f 1) in
-    IP_INVALID)
-      echo "  analysis: INTERFERENCE - $ip_result"
-      ;;
-    IP_VALID)
-      echo "  analysis: OK - $ip_result"
-      ;;
-    *)
-      echo "  anslysis: INCONCLUSIVE - $ip_result"
-  esac
 }
 
 function main() {


### PR DESCRIPTION
I removed the client IP, so it's safer for people to run this script and share the results unmodified. I also added the domain to the output for that reason.

Furthermore, I want to better separate what is measurement and what is analysis. Measurement are facts we observed. Analysis is redundant information that can be fully regenerated from the measurements.

Example output with a block page:
```
$ ./netanalysis/blocktest/measure.sh youtube.com
time: Mon Apr 26 14:58:43 UTC 2021
domain: youtube.com
client_country: US
client_as: AS701 MCI Communications Services, Inc. d/b/a Verizon Business

HTTP
  analysis: OK - Got expected response
SNI
  analysis: OK - Got TLS ServerHello
DNS_INJECTION
  root_nameserver: c.root-servers.net.
  query_response: status=NOERROR, num_answers=0, num_authorities=13
  analysis: OK - Received expected response
SYSTEM_RESOLVER
  resolver_country: US
  resolver_ip: 2001:19f0:5:663d:5400:2ff:fece:2f14
  resolver_as: AS20473 The Constant Company, LLC
  response_ips: 207.246.91.188
  ips_from_doh:  142.250.80.14
  tls_test: ip=207.246.91.188, error=60
  analysis: INTERFERENCE - Response 207.246.91.188 returned a certificate with an invalid CA
```

Response for a bogon IP:
```
$ ./netanalysis/blocktest/measure.sh youtube.com
time: Mon Apr 26 14:59:42 UTC 2021
domain: youtube.com
client_country: US
client_as: AS701 MCI Communications Services, Inc. d/b/a Verizon Business

HTTP
  analysis: OK - Got expected response
SNI
  analysis: OK - Got TLS ServerHello
DNS_INJECTION
  root_nameserver: l.root-servers.net.
  query_response: status=NOERROR, num_answers=0, num_authorities=13
  analysis: OK - Received expected response
SYSTEM_RESOLVER
  resolver_country: US
  resolver_ip: 2001:19f0:5:663d:5400:2ff:fece:2f14
  resolver_as: AS20473 The Constant Company, LLC
  response_ips: 0.0.0.0
  analysis: INTERFERENCE - Response IP 0.0.0.0 is a bogon
```


Response when using the TLS validation of ips:
```
$ ./netanalysis/blocktest/measure.sh www.google.com
time: Fri Apr 23 22:25:51 UTC 2021
domain: www.google.com
client_country: US
client_as: AS701 MCI Communications Services, Inc. d/b/a Verizon Business

HTTP
  analysis: OK - Got expected response
SNI
  analysis: OK - Got TLS ServerHello
DNS_INJECTION
  root_nameserver: a.root-servers.net.
  query_response: status=NOERROR, num_answers=0, num_authorities=13
  analysis: OK - Received expected response
SYSTEM_RESOLVER
  resolver_country: US
  resolver_ip: 172.253.214.16
  resolver_as: AS15169 Google LLC
  response_ips: 142.250.64.100
  ips_from_doh:  172.217.12.196
  tls_test: ip=142.250.64.100, error=0
  analysis: OK - Response IP 142.250.64.100 can produce certificate for domain www.google.com
```